### PR TITLE
[feature/640 & 645] -

### DIFF
--- a/cypress/integration/om-employees.spec.ts
+++ b/cypress/integration/om-employees.spec.ts
@@ -1,5 +1,6 @@
 // @ts-ignore
 import employee from '../fixtures/officemanagement/officemanagemententries.json';
+import {State} from '../../src/app/modules/shared/models/State';
 
 describe('Office Management (Mitarbeiter)', () => {
 
@@ -62,17 +63,22 @@ describe('Office Management (Mitarbeiter)', () => {
     visitAndWaitForRequests('/officeManagement');
     assertSelect('internal-check', 'Offen');
 
-    cy.intercept('PUT', 'http://localhost:*/stepentry/closeforoffice', {
+    cy.intercept('PUT', 'http://localhost:*/stepentry/updateEmployeeStateForOffice', {
       body: true
-    }).as('closeforoffice');
+    }).as('updateEmployeeStateForOffice');
 
-    cy.get('[data-cy="internal-check"]').click().get('[data-cy="option-done"]').click();
+    cy.get('app-state-select').click().get('[data-cy="option-done"]').click();
 
-    cy.get('@closeforoffice').its('request.body').should('deep.include', {
+    cy.wait('@updateEmployeeStateForOffice').then((interception) => {
+      cy.wrap(interception.request.body).as('requestData');
+    });
+
+    cy.get('@requestData').should('deep.include', {
       stepId: 2,
       employee: {
         ...employee[0].employee
-      }
+      },
+      newState: State.DONE
     });
 
     cy.fixture('officemanagement/officemanagemententries.json').then(jsonData => {

--- a/cypress/integration/om-enterpriseentries.spec.ts
+++ b/cypress/integration/om-enterpriseentries.spec.ts
@@ -76,7 +76,7 @@ describe('Office Management (Unternehmen)', () => {
 
     assertSelect('zep-times-released', 'Fertig')
       .get('.mat-select')
-      .should('have.class', 'mat-select-disabled');
+      .should('not.have.class', 'mat-select-disabled');
   });
 
   it('should display chargeability of external employees in progress when state "in progress" gets selected', () => {

--- a/src/app/modules/office-management/components/employee-card/employee-card.component.html
+++ b/src/app/modules/office-management/components/employee-card/employee-card.component.html
@@ -89,7 +89,7 @@
               *matHeaderCellDef>{{'office-management.table.internalCheckState' | translate}}</mat-header-cell>
             <mat-cell *matCellDef="let omEntry">
               <span class="mobile-label">{{'office-management.table.internalCheckState' | translate}}</span>
-              <app-state-select (selectionChange)="closeInternalCheck(omEntry)"
+              <app-state-select (selectionChange)="updateInternalCheck($event, omEntry)"
                                 [value]="omEntry.internalCheckState"
                                 data-cy="internal-check"></app-state-select>
             </mat-cell>

--- a/src/app/modules/office-management/components/employee-card/employee-card.component.ts
+++ b/src/app/modules/office-management/components/employee-card/employee-card.component.ts
@@ -23,6 +23,7 @@ import {ConfigService} from '../../../shared/services/config/config.service';
 import {Config} from '../../../shared/models/Config';
 import {firstValueFrom, mergeMap, Subscription, switchMap, zip} from 'rxjs';
 import {tap} from 'rxjs/operators';
+import {MatSelectChange} from '@angular/material/select';
 
 const moment = _moment;
 
@@ -181,11 +182,12 @@ export class EmployeeCardComponent implements OnInit, OnDestroy {
     this.notificationService.showSuccess(successMessage);
   }
 
-  closeInternalCheck(omEntry: ManagementEntry) {
+  updateInternalCheck($event: MatSelectChange, omEntry: ManagementEntry) {
+    const newState: State = $event.value;
     this.stepEntryService
-      .closeOfficeCheck(omEntry.employee, Step.CONTROL_INTERNAL_TIMES, this.getFormattedDate())
+      .updateEmployeeStateForOffice(omEntry.employee, Step.CONTROL_INTERNAL_TIMES, this.getFormattedDate(), newState)
       .subscribe(() => {
-        omEntry.internalCheckState = State.DONE;
+        omEntry.internalCheckState = newState;
       });
   }
 

--- a/src/app/modules/project-management/components/project-management.component.html
+++ b/src/app/modules/project-management/components/project-management.component.html
@@ -110,7 +110,7 @@
               </div>
             </div>
             <mat-panel-description>
-            <span [ngClass]="areAllProjectCheckStatesDone(pmEntry.projectName) ? 'green' : 'red'">
+            <span [ngClass]="pmEntry.allProjectCheckStatesDone ? 'green' : 'red'">
               {{'project-management.employeeDone' | translate}}
             </span>
             </mat-panel-description>
@@ -154,7 +154,7 @@
                 <mat-cell *matCellDef="let row" class="text-center">
                   <span class="mobile-label">{{'project-management.table.projectCheckState' | translate}}</span>
                   <app-state-select data-cy="project-state"
-                                    (selectionChange)="closeProjectCheck(pmEntry.projectName, row)"
+                                    (selectionChange)="updateProjectCheck($event, row, pmEntry)"
                                     [value]="row.projectCheckState"></app-state-select>
                 </mat-cell>
                 <mat-footer-cell *matFooterCellDef></mat-footer-cell>

--- a/src/app/modules/project-management/components/project-management.component.spec.ts
+++ b/src/app/modules/project-management/components/project-management.component.spec.ts
@@ -34,6 +34,7 @@ import {configuration} from '../../shared/constants/configuration';
 import {DatepickerMonthYearComponent} from '../../shared/components/datepicker-month-year/datepicker-month-year.component';
 import {ReactiveFormsModule} from '@angular/forms';
 import {NgxSkeletonLoaderModule} from 'ngx-skeleton-loader';
+import {ProjectManagementEntryExtension} from '../models/ProjectManagementEntryExtension';
 
 const moment = _moment;
 const DATE_FORMAT: string = configuration.dateFormat;
@@ -186,15 +187,17 @@ describe('ProjectManagementComponent', () => {
     selectionModel.select(ProjectManagementMock.projectManagementEntries[0].entries[0]);
     component.pmSelectionModels.set(ProjectManagementMock.project, selectionModel);
 
-    const areAllProjectCheckStatesDone = component.areAllProjectCheckStatesDone(ProjectManagementMock.project);
+    const projectToCheck = component.pmEntries.find(entry => entry.projectName === ProjectManagementMock.project);
+    component.checkAllProjectCheckStatesDone(projectToCheck);
 
-    expect(areAllProjectCheckStatesDone).toBeTrue();
+    expect(projectToCheck.allProjectCheckStatesDone).toBeTrue();
   });
 
-  it('#closeProjectCheckForSelected - should call stepEntryService.closeProjectCheck and set all entry.projectCheckState done', fakeAsync(() => {
+  it('#closeProjectCheckForSelected - should call stepEntryService.updateProjectCheck and set all entry.projectCheckState done', fakeAsync(() => {
     fixture.detectChanges();
 
-    spyOn(stepentryService, 'closeProjectCheck').and.returnValue(of(true));
+    spyOn(stepentryService, 'updateEmployeeStateForProject').and.returnValue(of(true));
+    const checkAllProjectCheckStatesDoneSpy = spyOn(component, 'checkAllProjectCheckStatesDone');
 
     component.pmEntries = ProjectManagementMock.projectManagementEntries;
 
@@ -206,23 +209,28 @@ describe('ProjectManagementComponent', () => {
     component.closeProjectCheckForSelected();
     flush();
 
-    expect(stepentryService.closeProjectCheck).toHaveBeenCalled();
+    expect(stepentryService.updateEmployeeStateForProject).toHaveBeenCalled();
     selectionModel.selected.forEach(entry => {
       expect(entry.projectCheckState).toEqual(State.DONE);
     });
+
+    expect(checkAllProjectCheckStatesDoneSpy).toHaveBeenCalledOnceWith(ProjectManagementMock.projectManagementEntries[0]);
   }));
 
-  it('#closeProjectCheck - should call stepEntryService.closeProjectCheck and set all entry.projectCheckState done', fakeAsync(() => {
+  it('#updateProjectCheck - should call stepEntryService.closeProjectCheck and set all entry.projectCheckState done', fakeAsync(() => {
     fixture.detectChanges();
 
-    spyOn(stepentryService, 'closeProjectCheck').and.returnValue(of(true));
+    spyOn(stepentryService, 'updateEmployeeStateForProject').and.returnValue(of(true));
+    const checkAllProjectCheckStatesDoneSpy = spyOn(component, 'checkAllProjectCheckStatesDone');
 
     const managementEntry: ManagementEntry = ProjectManagementMock.projectManagementEntries[0].entries[0];
 
-    component.closeProjectCheck(ProjectManagementMock.project, managementEntry);
+    component.updateProjectCheck({value: State.DONE, source: undefined}, managementEntry, ProjectManagementMock.projectManagementEntries[0]);
     flush();
 
-    expect(stepentryService.closeProjectCheck).toHaveBeenCalled();
+    expect(stepentryService.updateEmployeeStateForProject).toHaveBeenCalled();
+    expect(checkAllProjectCheckStatesDoneSpy).toHaveBeenCalled();
+
     expect(managementEntry.projectCheckState).toEqual(State.DONE);
   }));
 
@@ -538,7 +546,7 @@ describe('ProjectManagementComponent', () => {
       }
     ];
 
-    static projectManagementEntries: Array<ProjectManagementEntry> = [
+    static projectManagementEntries: Array<ProjectManagementEntryExtension> = [
       {
         entries: ProjectManagementMock.managementEntries,
         controlProjectState: ProjectState.DONE,

--- a/src/app/modules/project-management/components/project-management.component.spec.ts
+++ b/src/app/modules/project-management/components/project-management.component.spec.ts
@@ -34,7 +34,7 @@ import {configuration} from '../../shared/constants/configuration';
 import {DatepickerMonthYearComponent} from '../../shared/components/datepicker-month-year/datepicker-month-year.component';
 import {ReactiveFormsModule} from '@angular/forms';
 import {NgxSkeletonLoaderModule} from 'ngx-skeleton-loader';
-import {ProjectManagementEntryExtension} from '../models/ProjectManagementEntryExtension';
+import {ProjectManagementEntryViewModel} from '../models/ProjectManagementEntryViewModel';
 
 const moment = _moment;
 const DATE_FORMAT: string = configuration.dateFormat;
@@ -546,7 +546,7 @@ describe('ProjectManagementComponent', () => {
       }
     ];
 
-    static projectManagementEntries: Array<ProjectManagementEntryExtension> = [
+    static projectManagementEntries: Array<ProjectManagementEntryViewModel> = [
       {
         entries: ProjectManagementMock.managementEntries,
         controlProjectState: ProjectState.DONE,

--- a/src/app/modules/project-management/components/project-management.component.ts
+++ b/src/app/modules/project-management/components/project-management.component.ts
@@ -27,7 +27,7 @@ import {ProjectStateSelectComponent} from '../../shared/components/project-state
 import {ProjectCommentService} from '../../shared/services/project-comment/project-comment.service';
 import {SnackbarService} from '../../shared/services/snackbar/snackbar.service';
 import {forkJoin, mergeMap, Subscription, switchMap, tap, zip} from 'rxjs';
-import {ProjectManagementEntryExtension} from '../models/ProjectManagementEntryExtension';
+import {ProjectManagementEntryViewModel} from '../models/ProjectManagementEntryViewModel';
 import * as ProjectManagementComparator from '../ts/project-management-comparator';
 
 const moment = _moment;
@@ -39,7 +39,7 @@ const moment = _moment;
 })
 export class ProjectManagementComponent implements OnInit, OnDestroy {
 
-  pmEntries: Array<ProjectManagementEntryExtension>;
+  pmEntries: Array<ProjectManagementEntryViewModel>;
   displayedColumns = [
     'select',
     'employeeName',
@@ -185,7 +185,7 @@ export class ProjectManagementComponent implements OnInit, OnDestroy {
     }
   }
 
-  checkAllProjectCheckStatesDone(pmEntry: ProjectManagementEntryExtension) {
+  checkAllProjectCheckStatesDone(pmEntry: ProjectManagementEntryViewModel) {
     if (!pmEntry) {
       return;
     }
@@ -218,7 +218,7 @@ export class ProjectManagementComponent implements OnInit, OnDestroy {
     }
   }
 
-  updateProjectCheck($event: MatSelectChange, row: ManagementEntry, project: ProjectManagementEntryExtension) {
+  updateProjectCheck($event: MatSelectChange, row: ManagementEntry, project: ProjectManagementEntryViewModel) {
     const newState: State = $event.value;
     this.stepEntryService
       .updateEmployeeStateForProject(row.employee, project.projectName, this.getFormattedDate(), newState)

--- a/src/app/modules/project-management/components/project-management.component.ts
+++ b/src/app/modules/project-management/components/project-management.component.ts
@@ -26,7 +26,9 @@ import {TranslateService} from '@ngx-translate/core';
 import {ProjectStateSelectComponent} from '../../shared/components/project-state-select/project-state-select.component';
 import {ProjectCommentService} from '../../shared/services/project-comment/project-comment.service';
 import {SnackbarService} from '../../shared/services/snackbar/snackbar.service';
-import {mergeMap, Subscription, switchMap, tap, zip} from 'rxjs';
+import {forkJoin, mergeMap, Subscription, switchMap, tap, zip} from 'rxjs';
+import {ProjectManagementEntryExtension} from '../models/ProjectManagementEntryExtension';
+import * as ProjectManagementComparator from '../ts/project-management-comparator';
 
 const moment = _moment;
 
@@ -37,7 +39,7 @@ const moment = _moment;
 })
 export class ProjectManagementComponent implements OnInit, OnDestroy {
 
-  pmEntries: Array<ProjectManagementEntry>;
+  pmEntries: Array<ProjectManagementEntryExtension>;
   displayedColumns = [
     'select',
     'employeeName',
@@ -57,7 +59,7 @@ export class ProjectManagementComponent implements OnInit, OnDestroy {
   forProjectName: string;
   tooltipShowDelay = 500;
   tooltipPosition = 'above';
-  maxMonthDate: number = 1;
+  maxMonthDate = 1;
   dateSelectionSub: Subscription;
 
   constructor(private dialog: MatDialog,
@@ -91,7 +93,7 @@ export class ProjectManagementComponent implements OnInit, OnDestroy {
           this.selectedMonth = value[1];
         }),
         tap(() => {
-          this.pmEntries = null
+          this.pmEntries = null;
         }),
         switchMap(() => this.getPmEntries())
       ).subscribe(this.processPmEntries());
@@ -108,7 +110,6 @@ export class ProjectManagementComponent implements OnInit, OnDestroy {
     return pmEntries => {
       this.pmEntries = pmEntries;
       this.pmSelectionModels = new Map<string, SelectionModel<ManagementEntry>>();
-      this.pmEntries.sort((a, b) => a.projectName.localeCompare(b.projectName));
       this.pmEntries.forEach(pmEntry => {
           this.pmSelectionModels.set(pmEntry.projectName, new SelectionModel<ManagementEntry>(true, []));
 
@@ -119,12 +120,18 @@ export class ProjectManagementComponent implements OnInit, OnDestroy {
 
           pmEntry.entries = notAllDone.concat(allDone);
 
+          // call this method AFTER pmEntry.entries modifcations are done
+          this.checkAllProjectCheckStatesDone(pmEntry);
+
           this.projectCommentService.get(this.getFormattedDate(), pmEntry.projectName)
             .subscribe(projectComment => {
               pmEntry.projectComment = projectComment;
             });
         }
       );
+
+      // reason for reverse: see comparePmEntriesFn doc
+      this.pmEntries.sort(ProjectManagementComparator.comparePmEntriesFn).reverse();
     };
   }
 
@@ -178,29 +185,51 @@ export class ProjectManagementComponent implements OnInit, OnDestroy {
     }
   }
 
-  areAllProjectCheckStatesDone(projectName: string): boolean {
-    return this.findEntriesForProject(projectName).every(entry => entry.projectCheckState === State.DONE);
+  checkAllProjectCheckStatesDone(pmEntry: ProjectManagementEntryExtension) {
+    if (!pmEntry) {
+      return;
+    }
+
+    pmEntry.allProjectCheckStatesDone = pmEntry.entries.every(entry => entry.projectCheckState === State.DONE);
   }
 
   closeProjectCheckForSelected(): void {
+    const closeState = State.DONE;
+
     for (const [projectName, selectionModel] of this.pmSelectionModels.entries()) {
       if (selectionModel.selected.length > 0) {
-        for (const entry of selectionModel.selected) {
-          this.stepEntryService
-            .closeProjectCheck(entry.employee, projectName, this.getFormattedDate())
-            .subscribe(() => entry.projectCheckState = State.DONE);
-        }
+        const requests = selectionModel.selected.map(entry => {
+          return this.stepEntryService.updateEmployeeStateForProject(entry.employee, projectName, this.getFormattedDate(), closeState)
+        });
+
+        // call checkAllProjectCheckStatesDone after all requests are done, because it depends on emplyoee's states
+        forkJoin(requests).subscribe(results => {
+          results.forEach((success, index) => {
+            if(success) {
+              selectionModel.selected[index].projectCheckState = closeState;
+            }
+
+          });
+
+          this.checkAllProjectCheckStatesDone(this.pmEntries.find(entry => entry.projectName === projectName));
+        });
+
       }
     }
   }
 
-  closeProjectCheck(projectName: string, row: ManagementEntry) {
+  updateProjectCheck($event: MatSelectChange, row: ManagementEntry, project: ProjectManagementEntryExtension) {
+    const newState: State = $event.value;
     this.stepEntryService
-      .closeProjectCheck(row.employee, projectName, this.getFormattedDate())
-      .subscribe(() => row.projectCheckState = State.DONE);
+      .updateEmployeeStateForProject(row.employee, project.projectName, this.getFormattedDate(), newState)
+      .subscribe(() => {
+        row.projectCheckState = newState;
+        this.checkAllProjectCheckStatesDone(project);
+      });
   }
 
-  getFilteredAndSortedPmEntries(pmEntry: ProjectManagementEntry, projectCheckState: State, employeeCheckState: State, internalCheckState: State): Array<ManagementEntry> {
+  getFilteredAndSortedPmEntries(pmEntry: ProjectManagementEntry, projectCheckState: State, employeeCheckState: State,
+                                internalCheckState: State): Array<ManagementEntry> {
     return pmEntry.entries
       .filter(val => val.projectCheckState === projectCheckState &&
         val.employeeCheckState === employeeCheckState && val.internalCheckState === internalCheckState)
@@ -208,7 +237,8 @@ export class ProjectManagementComponent implements OnInit, OnDestroy {
         .localeCompare(b.employee.lastname.concat(b.employee.firstname)));
   }
 
-  onChangeControlProjectState($event: MatSelectChange, pmEntry: ProjectManagementEntry, controlProjectStateSelect: ProjectStateSelectComponent): void {
+  onChangeControlProjectState($event: MatSelectChange, pmEntry: ProjectManagementEntry,
+                              controlProjectStateSelect: ProjectStateSelectComponent): void {
     const newValue = $event.value as ProjectState;
     const preset = newValue !== 'NOT_RELEVANT' ? false : pmEntry.presetControlProjectState;
 
@@ -257,7 +287,7 @@ export class ProjectManagementComponent implements OnInit, OnDestroy {
           this.snackbarService.showSnackbarWithMessage(this.translate.instant('project-management.updateStatusError'));
           pmEntry.presetControlBillingState = !$event.checked;
         }
-      })
+      });
   }
 
   isProjectStateNotRelevant(projectState: ProjectState): boolean {
@@ -278,7 +308,7 @@ export class ProjectManagementComponent implements OnInit, OnDestroy {
     // Avoid reloading of page when the return button was clicked
     if (pmEntry.projectComment) {
       if (pmEntry.projectComment.comment !== comment) {
-        let oldComment = pmEntry.projectComment.comment;
+        const oldComment = pmEntry.projectComment.comment;
         pmEntry.projectComment.comment = comment;
         this.projectCommentService.update(pmEntry.projectComment)
           .subscribe((success) => {

--- a/src/app/modules/project-management/models/ProjectManagementEntryExtension.ts
+++ b/src/app/modules/project-management/models/ProjectManagementEntryExtension.ts
@@ -1,0 +1,8 @@
+import {ProjectManagementEntry} from './ProjectManagementEntry';
+
+/**
+ * extends ProjectManagementEntry by props which are needed for the view
+ */
+export interface ProjectManagementEntryExtension extends ProjectManagementEntry {
+  allProjectCheckStatesDone?: boolean;
+}

--- a/src/app/modules/project-management/models/ProjectManagementEntryViewModel.ts
+++ b/src/app/modules/project-management/models/ProjectManagementEntryViewModel.ts
@@ -3,6 +3,6 @@ import {ProjectManagementEntry} from './ProjectManagementEntry';
 /**
  * extends ProjectManagementEntry by props which are needed for the view
  */
-export interface ProjectManagementEntryExtension extends ProjectManagementEntry {
+export interface ProjectManagementEntryViewModel extends ProjectManagementEntry {
   allProjectCheckStatesDone?: boolean;
 }

--- a/src/app/modules/project-management/ts/project-management-comparator.spec.ts
+++ b/src/app/modules/project-management/ts/project-management-comparator.spec.ts
@@ -1,12 +1,12 @@
-import {ProjectManagementEntryExtension} from '../models/ProjectManagementEntryExtension';
+import {ProjectManagementEntryViewModel} from '../models/ProjectManagementEntryViewModel';
 import {ProjectState} from '../../shared/models/ProjectState';
 import {comparePmEntriesFn} from './project-management-comparator';
 
-function createTestProjectManagementEntity(projectName: string): ProjectManagementEntryExtension;
-function createTestProjectManagementEntity(projectName: string, allProjectCheckStatesDone?: boolean): ProjectManagementEntryExtension;
-function createTestProjectManagementEntity(projectName: string, allProjectCheckStatesDone?: boolean, controlProjectState?: ProjectState): ProjectManagementEntryExtension;
-function createTestProjectManagementEntity(projectName: string, allProjectCheckStatesDone?: boolean, controlProjectState?: ProjectState, controlBillingState?: ProjectState): ProjectManagementEntryExtension;
-function createTestProjectManagementEntity(projectName: string, allProjectCheckStatesDone?: boolean, controlProjectState?: ProjectState, controlBillingState?: ProjectState): ProjectManagementEntryExtension {
+function createTestProjectManagementEntity(projectName: string): ProjectManagementEntryViewModel;
+function createTestProjectManagementEntity(projectName: string, allProjectCheckStatesDone?: boolean): ProjectManagementEntryViewModel;
+function createTestProjectManagementEntity(projectName: string, allProjectCheckStatesDone?: boolean, controlProjectState?: ProjectState): ProjectManagementEntryViewModel;
+function createTestProjectManagementEntity(projectName: string, allProjectCheckStatesDone?: boolean, controlProjectState?: ProjectState, controlBillingState?: ProjectState): ProjectManagementEntryViewModel;
+function createTestProjectManagementEntity(projectName: string, allProjectCheckStatesDone?: boolean, controlProjectState?: ProjectState, controlBillingState?: ProjectState): ProjectManagementEntryViewModel {
   return {
     projectName: projectName,
     allProjectCheckStatesDone: allProjectCheckStatesDone,
@@ -21,7 +21,7 @@ function createTestProjectManagementEntity(projectName: string, allProjectCheckS
   }
 }
 
-function getProjectNames(entities: ProjectManagementEntryExtension[]) {
+function getProjectNames(entities: ProjectManagementEntryViewModel[]) {
   return entities.map(e => e.projectName);
 }
 
@@ -30,7 +30,7 @@ describe('ProjectManagementComparator', () => {
   it('should order by projectName alphabetically asc', () => {
 
     // given
-    const input: ProjectManagementEntryExtension[] = [
+    const input: ProjectManagementEntryViewModel[] = [
       createTestProjectManagementEntity('B'),
       createTestProjectManagementEntity('AAC'),
       createTestProjectManagementEntity('GH'),
@@ -58,7 +58,7 @@ describe('ProjectManagementComparator', () => {
   it('should order by allProjectCheckStatesDone before alphabetical', () => {
 
     // given
-    const input: ProjectManagementEntryExtension[] = [
+    const input: ProjectManagementEntryViewModel[] = [
       createTestProjectManagementEntity('B', true),
       createTestProjectManagementEntity('AAC', true),
       createTestProjectManagementEntity('GH', false),
@@ -86,7 +86,7 @@ describe('ProjectManagementComparator', () => {
   it('should order by controlProjectState before alphabetical', () => {
 
     // given
-    const input: ProjectManagementEntryExtension[] = [
+    const input: ProjectManagementEntryViewModel[] = [
       createTestProjectManagementEntity('AAC', true),
       createTestProjectManagementEntity('GH', true),
       createTestProjectManagementEntity('FIRST', true, ProjectState.WORK_IN_PROGRESS),
@@ -120,7 +120,7 @@ describe('ProjectManagementComparator', () => {
   it('should order by controlBillingState before alphabetical', () => {
 
     // given
-    const input: ProjectManagementEntryExtension[] = [
+    const input: ProjectManagementEntryViewModel[] = [
       createTestProjectManagementEntity('AAC', true),
       createTestProjectManagementEntity('GH', true),
       createTestProjectManagementEntity('FIRST', true, undefined, ProjectState.WORK_IN_PROGRESS),
@@ -154,7 +154,7 @@ describe('ProjectManagementComparator', () => {
   it('should order correctly by all criteria', () => {
 
     // given
-    const input: ProjectManagementEntryExtension[] = [
+    const input: ProjectManagementEntryViewModel[] = [
       createTestProjectManagementEntity('XYZ', true),
       createTestProjectManagementEntity('GH', true),
       createTestProjectManagementEntity('AAC', true),

--- a/src/app/modules/project-management/ts/project-management-comparator.spec.ts
+++ b/src/app/modules/project-management/ts/project-management-comparator.spec.ts
@@ -1,0 +1,183 @@
+import {ProjectManagementEntryExtension} from '../models/ProjectManagementEntryExtension';
+import {ProjectState} from '../../shared/models/ProjectState';
+import {comparePmEntriesFn} from './project-management-comparator';
+
+function createTestProjectManagementEntity(projectName: string): ProjectManagementEntryExtension;
+function createTestProjectManagementEntity(projectName: string, allProjectCheckStatesDone?: boolean): ProjectManagementEntryExtension;
+function createTestProjectManagementEntity(projectName: string, allProjectCheckStatesDone?: boolean, controlProjectState?: ProjectState): ProjectManagementEntryExtension;
+function createTestProjectManagementEntity(projectName: string, allProjectCheckStatesDone?: boolean, controlProjectState?: ProjectState, controlBillingState?: ProjectState): ProjectManagementEntryExtension;
+function createTestProjectManagementEntity(projectName: string, allProjectCheckStatesDone?: boolean, controlProjectState?: ProjectState, controlBillingState?: ProjectState): ProjectManagementEntryExtension {
+  return {
+    projectName: projectName,
+    allProjectCheckStatesDone: allProjectCheckStatesDone,
+    entries: [],
+    controlProjectState: controlProjectState || ProjectState.DONE,
+    controlBillingState: controlBillingState || ProjectState.DONE,
+    presetControlProjectState: false,
+    presetControlBillingState: false,
+    projectComment: undefined,
+    aggregatedBillableWorkTimeInSeconds: 0,
+    aggregatedNonBillableWorkTimeInSeconds: 0
+  }
+}
+
+function getProjectNames(entities: ProjectManagementEntryExtension[]) {
+  return entities.map(e => e.projectName);
+}
+
+describe('ProjectManagementComparator', () => {
+
+  it('should order by projectName alphabetically asc', () => {
+
+    // given
+    const input: ProjectManagementEntryExtension[] = [
+      createTestProjectManagementEntity('B'),
+      createTestProjectManagementEntity('AAC'),
+      createTestProjectManagementEntity('GH'),
+      createTestProjectManagementEntity('AAA'),
+      createTestProjectManagementEntity('XYZ'),
+      createTestProjectManagementEntity('AAB')
+    ];
+
+    const expectedSortOrder = [
+      'AAA',
+      'AAB',
+      'AAC',
+      'B',
+      'GH',
+      'XYZ',
+    ];
+
+    // when
+    input.sort(comparePmEntriesFn).reverse();
+
+    // then
+    expectedSortOrder.forEach((val, index) => expect(val).toEqual(input[index].projectName));
+  });
+
+  it('should order by allProjectCheckStatesDone before alphabetical', () => {
+
+    // given
+    const input: ProjectManagementEntryExtension[] = [
+      createTestProjectManagementEntity('B', true),
+      createTestProjectManagementEntity('AAC', true),
+      createTestProjectManagementEntity('GH', false),
+      createTestProjectManagementEntity('AAA', true),
+      createTestProjectManagementEntity('XYZ', false),
+      createTestProjectManagementEntity('AAB', true)
+    ];
+
+    const expectedSortOrder = [
+      'GH',
+      'XYZ',
+      'AAA',
+      'AAB',
+      'AAC',
+      'B'
+    ];
+
+    // when
+    input.sort(comparePmEntriesFn).reverse();
+
+    // then
+    expectedSortOrder.forEach((val, index) => expect(val).toEqual(input[index].projectName));
+  });
+
+  it('should order by controlProjectState before alphabetical', () => {
+
+    // given
+    const input: ProjectManagementEntryExtension[] = [
+      createTestProjectManagementEntity('AAC', true),
+      createTestProjectManagementEntity('GH', true),
+      createTestProjectManagementEntity('FIRST', true, ProjectState.WORK_IN_PROGRESS),
+      createTestProjectManagementEntity('SECOND', true, ProjectState.OPEN),
+      createTestProjectManagementEntity('AAA', true),
+      createTestProjectManagementEntity('XYZ', true),
+      createTestProjectManagementEntity('DONE', true, ProjectState.DONE),
+      createTestProjectManagementEntity('NOT_RELEVANT', true, ProjectState.NOT_RELEVANT),
+      createTestProjectManagementEntity('AAB', true)
+    ];
+
+    const expectedSortOrder = [
+      'FIRST',
+      'SECOND',
+      'AAA',
+      'AAB',
+      'AAC',
+      'DONE',
+      'GH',
+      'NOT_RELEVANT',
+      'XYZ',
+    ];
+
+    // when
+    input.sort(comparePmEntriesFn).reverse();
+
+    // then
+    expectedSortOrder.forEach((val, index) => expect(val).toEqual(input[index].projectName));
+  });
+
+  it('should order by controlBillingState before alphabetical', () => {
+
+    // given
+    const input: ProjectManagementEntryExtension[] = [
+      createTestProjectManagementEntity('AAC', true),
+      createTestProjectManagementEntity('GH', true),
+      createTestProjectManagementEntity('FIRST', true, undefined, ProjectState.WORK_IN_PROGRESS),
+      createTestProjectManagementEntity('SECOND', true, undefined, ProjectState.OPEN),
+      createTestProjectManagementEntity('NOT_RELEVANT', true, undefined, ProjectState.NOT_RELEVANT),
+      createTestProjectManagementEntity('DONE', true, undefined, ProjectState.DONE),
+      createTestProjectManagementEntity('AAA', true),
+      createTestProjectManagementEntity('XYZ', true),
+      createTestProjectManagementEntity('AAB', true)
+    ];
+
+    const expectedSortOrder = [
+      'FIRST',
+      'SECOND',
+      'AAA',
+      'AAB',
+      'AAC',
+      'DONE',
+      'GH',
+      'NOT_RELEVANT',
+      'XYZ',
+    ];
+
+    // when
+    input.sort(comparePmEntriesFn).reverse();
+
+    // then
+    expectedSortOrder.forEach((val, index) => expect(val).toEqual(input[index].projectName));
+  });
+
+  it('should order correctly by all criteria', () => {
+
+    // given
+    const input: ProjectManagementEntryExtension[] = [
+      createTestProjectManagementEntity('XYZ', true),
+      createTestProjectManagementEntity('GH', true),
+      createTestProjectManagementEntity('AAC', true),
+      createTestProjectManagementEntity('FIRST', true, undefined, ProjectState.WORK_IN_PROGRESS),
+      createTestProjectManagementEntity('SECOND', false),
+      createTestProjectManagementEntity('THIRD', true, ProjectState.OPEN),
+      createTestProjectManagementEntity('AAB', true)
+    ];
+
+    const expectedSortOrder = [
+      'FIRST',
+      'SECOND',
+      'THIRD',
+      'AAB',
+      'AAC',
+      'GH',
+      'XYZ',
+    ];
+
+    // when
+    input.sort(comparePmEntriesFn).reverse();
+
+    // then
+    expectedSortOrder.forEach((val, index) => expect(val).toEqual(input[index].projectName));
+  });
+});

--- a/src/app/modules/project-management/ts/project-management-comparator.ts
+++ b/src/app/modules/project-management/ts/project-management-comparator.ts
@@ -1,5 +1,5 @@
 import {booleanCompare, stringCompare} from '../../shared/utils/compareUtils';
-import {ProjectManagementEntryExtension} from '../models/ProjectManagementEntryExtension';
+import {ProjectManagementEntryViewModel} from '../models/ProjectManagementEntryViewModel';
 import {ProjectState} from '../../shared/models/ProjectState';
 
 /**
@@ -14,7 +14,7 @@ import {ProjectState} from '../../shared/models/ProjectState';
  *
  * !!! AUFRUFER MUSS SORT().REVERSE aufrufen, weil javascript standardmäßig asc sortiert und hier die logik quasi invertiert ist !!!
  */
-export function comparePmEntriesFn(a: ProjectManagementEntryExtension, b: ProjectManagementEntryExtension) {
+export function comparePmEntriesFn(a: ProjectManagementEntryViewModel, b: ProjectManagementEntryViewModel) {
   const isTodoA = isTodoProject(a);
   const isTodoB = isTodoProject(b);
 
@@ -25,7 +25,7 @@ export function comparePmEntriesFn(a: ProjectManagementEntryExtension, b: Projec
 
 const todoProjectStates = [ProjectState.OPEN, ProjectState.WORK_IN_PROGRESS];
 
-function isTodoProject(project: ProjectManagementEntryExtension) {
+function isTodoProject(project: ProjectManagementEntryViewModel) {
   return !project.allProjectCheckStatesDone
     || todoProjectStates.includes(project.controlProjectState)
     || todoProjectStates.includes(project.controlBillingState);

--- a/src/app/modules/project-management/ts/project-management-comparator.ts
+++ b/src/app/modules/project-management/ts/project-management-comparator.ts
@@ -1,0 +1,32 @@
+import {booleanCompare, stringCompare} from '../../shared/utils/compareUtils';
+import {ProjectManagementEntryExtension} from '../models/ProjectManagementEntryExtension';
+import {ProjectState} from '../../shared/models/ProjectState';
+
+/**
+ * Die Projekte sollen wie folgt sortiert werden:
+ * Projekte, bei denen etwas zutun ist, sollen vor projekte, bei denen nichts zutun ist, sein, sprich "TodoProject" > "Project"
+ * Ein Project ist ein "TodoProject", sobald eines der folgenden Kriterien zutrifft:
+ *     - Mitarbeiter Überprüfung nicht fertig
+ *     - Projectcontrolling Status ist 'Offen' oder 'In Arbeit'
+ *     - Projectbilling Status ist 'Offen' oder 'In Arbeit'
+ * Danach soll erst nach den Projektnamen alphabetisch aufsteigend sortiert werden (AAA vor BBB)
+ *
+ *
+ * !!! AUFRUFER MUSS SORT().REVERSE aufrufen, weil javascript standardmäßig asc sortiert und hier die logik quasi invertiert ist !!!
+ */
+export function comparePmEntriesFn(a: ProjectManagementEntryExtension, b: ProjectManagementEntryExtension) {
+  const isTodoA = isTodoProject(a);
+  const isTodoB = isTodoProject(b);
+
+
+  return booleanCompare(isTodoA, isTodoB)
+    || stringCompare(b.projectName, a.projectName); // reversed -> DESC order -> AAA > BBB
+}
+
+const todoProjectStates = [ProjectState.OPEN, ProjectState.WORK_IN_PROGRESS];
+
+function isTodoProject(project: ProjectManagementEntryExtension) {
+  return !project.allProjectCheckStatesDone
+    || todoProjectStates.includes(project.controlProjectState)
+    || todoProjectStates.includes(project.controlBillingState);
+}

--- a/src/app/modules/shared/components/project-state-select/project-state-select.component.html
+++ b/src/app/modules/shared/components/project-state-select/project-state-select.component.html
@@ -3,8 +3,7 @@
             [(value)]="value"
             [class.select-green]="select.value === ProjectState.DONE || select.value === ProjectState.NOT_RELEVANT"
             [class.select-red]="select.value === ProjectState.OPEN"
-            [class.select-yellow]="select.value === ProjectState.WORK_IN_PROGRESS"
-            [disabled]="isDoneSelected">
+            [class.select-yellow]="select.value === ProjectState.WORK_IN_PROGRESS">
   <mat-option [disabled]="isInProgressSelected"
               [value]="ProjectState.OPEN"
               data-cy="option-open">{{'STATE.OPEN' | translate}}</mat-option>

--- a/src/app/modules/shared/components/project-state-select/project-state-select.component.spec.ts
+++ b/src/app/modules/shared/components/project-state-select/project-state-select.component.spec.ts
@@ -62,7 +62,7 @@ describe('ProjectStateSelectComponent', () => {
     });
   }));
 
-  it('#selectStateDone - should disable the select when state is DONE', fakeAsync(() => {
+  it('#selectStateDone - should NOT disable the select when state is DONE', fakeAsync(() => {
     fixture.detectChanges();
 
     component.select.open();
@@ -80,7 +80,7 @@ describe('ProjectStateSelectComponent', () => {
     flush();
 
     expect(component.isDoneSelected).toBeTrue();
-    expect(component.select.disabled).toBeTrue();
+    expect(component.select.disabled).toBeFalsy();
   }));
 
   it('#selectStateWorkInProgress - should disable option OPEN when WIP is selected', fakeAsync(() => {

--- a/src/app/modules/shared/components/state-select/state-select.component.html
+++ b/src/app/modules/shared/components/state-select/state-select.component.html
@@ -2,7 +2,6 @@
             (selectionChange)="onSelectionChange($event)"
             [class.select-green]="select.value === State.DONE"
             [class.select-red]="select.value === State.OPEN"
-            [disabled]="value === State.DONE"
             [value]="value">
   <mat-option [value]="State.OPEN" data-cy="option-open">{{'STATE.OPEN' | translate}}</mat-option>
   <mat-option [value]="State.DONE" data-cy="option-done">{{'STATE.DONE' | translate}}</mat-option>

--- a/src/app/modules/shared/components/state-select/state-select.component.ts
+++ b/src/app/modules/shared/components/state-select/state-select.component.ts
@@ -23,6 +23,6 @@ export class StateSelectComponent implements AfterViewChecked {
 
   onSelectionChange(selectChange: MatSelectChange): void {
     this.selectionChange.emit(selectChange);
-    this.value = State.DONE;
+    this.value = selectChange.value;
   }
 }

--- a/src/app/modules/shared/models/UpdateEmployeeStep.ts
+++ b/src/app/modules/shared/models/UpdateEmployeeStep.ts
@@ -1,18 +1,16 @@
 import {Employee} from './Employee';
 import {State} from './State';
 
-export class ProjectStep {
+export class UpdateEmployeeStep {
 
   stepId: number;
   employee: Employee;
-  projectName: string;
   currentMonthYear: string;
   newState: State;
 
-  constructor(stepId: number, employee: Employee, projectName: string, currentMonthYear: string, newState: State) {
+  constructor(stepId: number, employee: Employee, currentMonthYear: string, newState: State) {
     this.stepId = stepId;
     this.employee = employee;
-    this.projectName = projectName;
     this.currentMonthYear = currentMonthYear;
     this.newState = newState;
   }

--- a/src/app/modules/shared/services/comment/comment.service.ts
+++ b/src/app/modules/shared/services/comment/comment.service.ts
@@ -28,6 +28,7 @@ export class CommentService {
   }
 
   setStatusDone(comment: Comment): Observable<number> {
+    this.deleteViewModelProps(comment);
     return this.httpClient.put<number>(this.config.getBackendUrlWithContext('/comments/setdone'), comment);
   }
 
@@ -50,6 +51,7 @@ export class CommentService {
   }
 
   updateComment(comment: Comment): Observable<any> {
+    this.deleteViewModelProps(comment);
     return this.httpClient.put(
       this.config.getBackendUrlWithContext('/comments'),
       comment
@@ -58,5 +60,13 @@ export class CommentService {
 
   deleteComment(comment: Comment): Observable<any> {
     return this.httpClient.delete(this.config.getBackendUrlWithContext('/comments/' + comment.id));
+  }
+
+  /**
+   * remove props which got added for ViewModel purposes, to avoid 'unrecognised field ...' exceptions from backend and to avoid unnecessary
+   * traffic
+   */
+  private deleteViewModelProps(comment: Comment) {
+    delete comment.isEditing;
   }
 }

--- a/src/app/modules/shared/services/stepentries/stepentries.service.spec.ts
+++ b/src/app/modules/shared/services/stepentries/stepentries.service.spec.ts
@@ -6,6 +6,7 @@ import {ConfigService} from '../config/config.service';
 import {Employee} from '../../models/Employee';
 import {Step} from '../../models/Step';
 import {HttpResponse} from '@angular/common/http';
+import {State} from '../../models/State';
 
 describe('StepentriesService', () => {
 
@@ -38,25 +39,25 @@ describe('StepentriesService', () => {
     testRequest.event(new HttpResponse<boolean>({body: true}));
   });
 
-  it('#closeOfficeCheck - should return true', (done) => {
-    stepentriesService.closeOfficeCheck(StepentriesMock.employee, Step.ACCEPT_TIMES, StepentriesMock.monthYear)
+  it('#updateEmployeeStateForOffice - should return true', (done) => {
+    stepentriesService.updateEmployeeStateForOffice(StepentriesMock.employee, Step.ACCEPT_TIMES, StepentriesMock.monthYear, State.DONE)
       .subscribe(success => {
         expect(success).toEqual(true);
         done();
       });
 
-    const testRequest = httpTestingController.expectOne(configService.getBackendUrlWithContext('/stepentry/closeforoffice'));
+    const testRequest = httpTestingController.expectOne(configService.getBackendUrlWithContext('/stepentry/updateEmployeeStateForOffice'));
     testRequest.event(new HttpResponse<boolean>({body: true}));
   });
 
-  it('#closeProjectCheck - should return true', (done) => {
-    stepentriesService.closeProjectCheck(StepentriesMock.employee, StepentriesMock.projectName, StepentriesMock.monthYear)
+  it('#updateEmployeeStateForProject - should return true', (done) => {
+    stepentriesService.updateEmployeeStateForProject(StepentriesMock.employee, StepentriesMock.projectName, StepentriesMock.monthYear, State.DONE)
       .subscribe(success => {
         expect(success).toEqual(true);
         done();
       });
 
-    const testRequest = httpTestingController.expectOne(configService.getBackendUrlWithContext('/stepentry/closeforproject'));
+    const testRequest = httpTestingController.expectOne(configService.getBackendUrlWithContext('/stepentry/updateEmployeeStateForProject'));
     testRequest.event(new HttpResponse<boolean>({body: true}));
   });
 

--- a/src/app/modules/shared/services/stepentries/stepentries.service.ts
+++ b/src/app/modules/shared/services/stepentries/stepentries.service.ts
@@ -5,7 +5,9 @@ import {HttpClient} from '@angular/common/http';
 import {ConfigService} from '../config/config.service';
 import {EmployeeStep} from '../../models/EmployeeStep';
 import {Step} from '../../models/Step';
+import {State} from '../../models/State';
 import {ProjectStep} from '../../models/ProjectStep';
+import {UpdateEmployeeStep} from '../../models/UpdateEmployeeStep';
 
 @Injectable({
   providedIn: 'root'
@@ -25,17 +27,21 @@ export class StepentriesService {
     );
   }
 
-  closeOfficeCheck(employee: Employee, step: Step, currentMonthYear: string): Observable<boolean> {
+  updateEmployeeStateForOffice(employee: Employee, step: Step, currentMonthYear: string, newState: State): Observable<boolean> {
     return this.httpClient.put<boolean>(
-      this.config.getBackendUrlWithContext('/stepentry/closeforoffice'),
-      new EmployeeStep(step, employee, currentMonthYear)
+      this.config.getBackendUrlWithContext('/stepentry/updateEmployeeStateForOffice'),
+      new UpdateEmployeeStep(step, employee, currentMonthYear, newState)
     );
   }
 
-  closeProjectCheck(employee: Employee, projectName: string, currentMonthYear: string): Observable<boolean> {
+  /**
+   *
+   * @return true if the operation was successful
+   */
+  updateEmployeeStateForProject(employee: Employee, projectName: string, currentMonthYear: string, newState: State): Observable<boolean> {
     return this.httpClient.put<boolean>(
-      this.config.getBackendUrlWithContext('/stepentry/closeforproject'),
-      new ProjectStep(Step.CONTROL_TIME_EVIDENCES, employee, projectName, currentMonthYear)
+      this.config.getBackendUrlWithContext('/stepentry/updateEmployeeStateForProject'),
+      new ProjectStep(Step.CONTROL_TIME_EVIDENCES, employee, projectName, currentMonthYear, newState)
     );
   }
 }

--- a/src/app/modules/shared/utils/compareUtils.ts
+++ b/src/app/modules/shared/utils/compareUtils.ts
@@ -1,0 +1,7 @@
+export function booleanCompare(a: boolean, b: boolean) {
+  // double negation (!!) is used to convert undefined/null to false, otherwise Number(undefined/null) would return NaN
+  return Number(!!a) - Number(!!b);
+}
+export function stringCompare(a: string, b: string) {
+  return a.localeCompare(b);
+}


### PR DESCRIPTION
(645) PM-View: Offene Projekte (alphabetisch) oben anzeigen (Logik erklärt in project-management-comparator.ts)
(640) States und Steps sollen in Projekt und Office View auch von Fertig auf Offen gesetzt werden können. D.h. nicht mehr disablen, wenn state = Done. Dafür wurde ich Backend einiges umgebaut und aufgeräumt - die UI wurde entsprechend auch aufgeräumt und unit tests wurden angepasst.